### PR TITLE
Reduced Schedule

### DIFF
--- a/.github/workflows/update-jdk-11.yml
+++ b/.github/workflows/update-jdk-11.yml
@@ -1,7 +1,7 @@
 name: Update JDK 11
 "on":
     schedule:
-        - cron: 30 * * * *
+        - cron: 0 5 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-jdk-15.yml
+++ b/.github/workflows/update-jdk-15.yml
@@ -1,7 +1,7 @@
 name: Update JDK 15
 "on":
     schedule:
-        - cron: 30 * * * *
+        - cron: 0 5 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-jdk-8.yml
+++ b/.github/workflows/update-jdk-8.yml
@@ -1,7 +1,7 @@
 name: Update JDK 8
 "on":
     schedule:
-        - cron: 30 * * * *
+        - cron: 0 5 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-jre-11.yml
+++ b/.github/workflows/update-jre-11.yml
@@ -1,7 +1,7 @@
 name: Update JRE 11
 "on":
     schedule:
-        - cron: 30 * * * *
+        - cron: 0 5 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-jre-15.yml
+++ b/.github/workflows/update-jre-15.yml
@@ -1,7 +1,7 @@
 name: Update JRE 15
 "on":
     schedule:
-        - cron: 30 * * * *
+        - cron: 0 5 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-jre-8.yml
+++ b/.github/workflows/update-jre-8.yml
@@ -1,7 +1,7 @@
 name: Update JRE 8
 "on":
     schedule:
-        - cron: 30 * * * *
+        - cron: 0 5 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-jvmkill.yml
+++ b/.github/workflows/update-jvmkill.yml
@@ -1,7 +1,7 @@
 name: Update jvmkill
 "on":
     schedule:
-        - cron: 30 * * * *
+        - cron: 0 5 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:


### PR DESCRIPTION
Previously, the regularly scheduled builds exhausted the free tier of GitHub actions in some orgs.  This change reduces the number of hours and number of days that these scheduled events will run.