### PR TITLE
Change the order of buildplan candidates such that it goes from most specific to least specific

### DIFF
--- a/liberica/detect.go
+++ b/liberica/detect.go
@@ -29,17 +29,11 @@ func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 			{
 				Provides: []libcnb.BuildPlanProvide{
 					{Name: "jdk"},
+					{Name: "native-image-builder"},
 					{Name: "jre"},
 				},
-			},
-			{
-				Provides: []libcnb.BuildPlanProvide{
+				Requires: []libcnb.BuildPlanRequire{
 					{Name: "jdk"},
-				},
-			},
-			{
-				Provides: []libcnb.BuildPlanProvide{
-					{Name: "jre"},
 				},
 			},
 			{
@@ -54,11 +48,17 @@ func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 			{
 				Provides: []libcnb.BuildPlanProvide{
 					{Name: "jdk"},
-					{Name: "native-image-builder"},
 					{Name: "jre"},
 				},
-				Requires: []libcnb.BuildPlanRequire{
+			},
+			{
+				Provides: []libcnb.BuildPlanProvide{
 					{Name: "jdk"},
+				},
+			},
+			{
+				Provides: []libcnb.BuildPlanProvide{
+					{Name: "jre"},
 				},
 			},
 		},

--- a/liberica/detect_test.go
+++ b/liberica/detect_test.go
@@ -17,8 +17,9 @@
 package liberica_test
 
 import (
-	"github.com/paketo-buildpacks/bellsoft-liberica/liberica"
 	"testing"
+
+	"github.com/paketo-buildpacks/bellsoft-liberica/liberica"
 
 	"github.com/buildpacks/libcnb"
 	. "github.com/onsi/gomega"
@@ -40,17 +41,11 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				{
 					Provides: []libcnb.BuildPlanProvide{
 						{Name: "jdk"},
+						{Name: "native-image-builder"},
 						{Name: "jre"},
 					},
-				},
-				{
-					Provides: []libcnb.BuildPlanProvide{
+					Requires: []libcnb.BuildPlanRequire{
 						{Name: "jdk"},
-					},
-				},
-				{
-					Provides: []libcnb.BuildPlanProvide{
-						{Name: "jre"},
 					},
 				},
 				{
@@ -65,11 +60,17 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				{
 					Provides: []libcnb.BuildPlanProvide{
 						{Name: "jdk"},
-						{Name: "native-image-builder"},
 						{Name: "jre"},
 					},
-					Requires: []libcnb.BuildPlanRequire{
+				},
+				{
+					Provides: []libcnb.BuildPlanProvide{
 						{Name: "jdk"},
+					},
+				},
+				{
+					Provides: []libcnb.BuildPlanProvide{
+						{Name: "jre"},
 					},
 				},
 			},


### PR DESCRIPTION

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary

This changes the order of the buildplans generated at detection. It orders them from most specific to least specific. The rationale behind this is that the lifecycle will process buildplans in depth-first fashion and it will stop when it finds the first successful buildplan candidate (successful meaning all the provides/requires are met for all passing buildpacks). Previously, you could get into a condition where a less specific candidate buildpack would be selected over a more specific selection just because the less specific candidate was listed first. Changing the order will ensure that the most specific plan is picked first, which is the desired behavior.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
