### PR TITLE
Fixes bug where JRE was being installed into the launch container for native-image apps

### DIFF
--- a/liberica/build.go
+++ b/liberica/build.go
@@ -18,8 +18,9 @@ package liberica
 
 import (
 	"fmt"
-	"github.com/paketo-buildpacks/libjvm"
 	"strings"
+
+	"github.com/paketo-buildpacks/libjvm"
 
 	"github.com/buildpacks/libcnb"
 	"github.com/heroku/color"
@@ -122,7 +123,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 		result.BOM.Entries = append(result.BOM.Entries, be)
 	}
 
-	if jreRequired {
+	if jreRequired && !nativeImage {
 		dt := libjvm.JREType
 		depJRE, err := dr.Resolve("jre", v)
 

--- a/liberica/build_test.go
+++ b/liberica/build_test.go
@@ -38,7 +38,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	)
 
 	it("contributes JDK", func() {
-		ctx.Plan.Entries = append(ctx.Plan.Entries, libcnb.BuildpackPlanEntry{Name: "jdk"})
+		ctx.Plan.Entries = append(
+			ctx.Plan.Entries,
+			libcnb.BuildpackPlanEntry{Name: "jdk"})
 		ctx.Buildpack.Metadata = map[string]interface{}{
 			"dependencies": []map[string]interface{}{
 				{
@@ -63,7 +65,11 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("contributes NIK", func() {
-		ctx.Plan.Entries = append(ctx.Plan.Entries, libcnb.BuildpackPlanEntry{Name: "native-image-builder"})
+		ctx.Plan.Entries = append(
+			ctx.Plan.Entries,
+			libcnb.BuildpackPlanEntry{Name: "jdk", Metadata: map[string]interface{}{}},
+			libcnb.BuildpackPlanEntry{Name: "native-image-builder"},
+		)
 		ctx.Buildpack.Metadata = map[string]interface{}{
 			"dependencies": []map[string]interface{}{
 				{
@@ -87,12 +93,13 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(result.BOM.Entries[0].Build).To(BeTrue())
 	})
 
-	it("contributes NIK if both native-image-builder and jdk are present", func() {
+	it("contributes NIK alternative buildplan", func() {
 		// NIK includes a JDK, so we don't need a second JDK
 		ctx.Plan.Entries = append(
 			ctx.Plan.Entries,
 			libcnb.BuildpackPlanEntry{Name: "native-image-builder"},
-			libcnb.BuildpackPlanEntry{Name: "jdk"})
+			libcnb.BuildpackPlanEntry{Name: "jdk", Metadata: map[string]interface{}{}},
+			libcnb.BuildpackPlanEntry{Name: "jre", Metadata: map[string]interface{}{}})
 		ctx.Buildpack.Metadata = map[string]interface{}{
 			"dependencies": []map[string]interface{}{
 				{
@@ -117,7 +124,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("contributes JRE", func() {
-		ctx.Plan.Entries = append(ctx.Plan.Entries, libcnb.BuildpackPlanEntry{Name: "jre", Metadata: LaunchContribution})
+		ctx.Plan.Entries = append(
+			ctx.Plan.Entries,
+			libcnb.BuildpackPlanEntry{Name: "jre", Metadata: LaunchContribution})
 		ctx.Buildpack.Metadata = map[string]interface{}{
 			"dependencies": []map[string]interface{}{
 				{
@@ -145,7 +154,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("contributes security-providers-classpath-8 before Java 9", func() {
-		ctx.Plan.Entries = append(ctx.Plan.Entries, libcnb.BuildpackPlanEntry{Name: "jre", Metadata: LaunchContribution})
+		ctx.Plan.Entries = append(
+			ctx.Plan.Entries,
+			libcnb.BuildpackPlanEntry{Name: "jre", Metadata: LaunchContribution})
 		ctx.Buildpack.Metadata = map[string]interface{}{
 			"dependencies": []map[string]interface{}{
 				{
@@ -173,7 +184,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("contributes security-providers-classpath-9 after Java 9", func() {
-		ctx.Plan.Entries = append(ctx.Plan.Entries, libcnb.BuildpackPlanEntry{Name: "jre", Metadata: LaunchContribution})
+		ctx.Plan.Entries = append(
+			ctx.Plan.Entries,
+			libcnb.BuildpackPlanEntry{Name: "jre", Metadata: LaunchContribution})
 		ctx.Buildpack.Metadata = map[string]interface{}{
 			"dependencies": []map[string]interface{}{
 				{
@@ -201,7 +214,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("contributes JDK when no JRE and only a JRE is wanted", func() {
-		ctx.Plan.Entries = append(ctx.Plan.Entries, libcnb.BuildpackPlanEntry{Name: "jre", Metadata: LaunchContribution})
+		ctx.Plan.Entries = append(
+			ctx.Plan.Entries,
+			libcnb.BuildpackPlanEntry{Name: "jre", Metadata: LaunchContribution})
 		ctx.Buildpack.Metadata = map[string]interface{}{
 			"dependencies": []map[string]interface{}{
 				{
@@ -228,8 +243,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("contributes JDK when no JRE and both a JDK and JRE are wanted", func() {
-		ctx.Plan.Entries = append(ctx.Plan.Entries, libcnb.BuildpackPlanEntry{Name: "jdk", Metadata: LaunchContribution})
-		ctx.Plan.Entries = append(ctx.Plan.Entries, libcnb.BuildpackPlanEntry{Name: "jre", Metadata: LaunchContribution})
+		ctx.Plan.Entries = append(
+			ctx.Plan.Entries,
+			libcnb.BuildpackPlanEntry{Name: "jdk", Metadata: LaunchContribution},
+			libcnb.BuildpackPlanEntry{Name: "jre", Metadata: LaunchContribution})
 		ctx.Buildpack.Metadata = map[string]interface{}{
 			"dependencies": []map[string]interface{}{
 				{
@@ -312,8 +329,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		it("contributes JDK when specified explicitly in $BP_JVM_TYPE", func() {
 			Expect(os.Setenv("BP_JVM_TYPE", "jdk")).To(Succeed())
 
-			ctx.Plan.Entries = append(ctx.Plan.Entries, libcnb.BuildpackPlanEntry{Name: "jdk", Metadata: LaunchContribution})
-			ctx.Plan.Entries = append(ctx.Plan.Entries, libcnb.BuildpackPlanEntry{Name: "jre", Metadata: LaunchContribution})
+			ctx.Plan.Entries = append(
+				ctx.Plan.Entries,
+				libcnb.BuildpackPlanEntry{Name: "jdk", Metadata: LaunchContribution},
+				libcnb.BuildpackPlanEntry{Name: "jre", Metadata: LaunchContribution})
 			ctx.Buildpack.Metadata = map[string]interface{}{
 				"dependencies": []map[string]interface{}{
 					{
@@ -342,8 +361,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		it("contributes JRE when specified explicitly in $BP_JVM_TYPE", func() {
 			Expect(os.Setenv("BP_JVM_TYPE", "jre")).To(Succeed())
 
-			ctx.Plan.Entries = append(ctx.Plan.Entries, libcnb.BuildpackPlanEntry{Name: "jdk", Metadata: LaunchContribution})
-			ctx.Plan.Entries = append(ctx.Plan.Entries, libcnb.BuildpackPlanEntry{Name: "jre", Metadata: LaunchContribution})
+			ctx.Plan.Entries = append(
+				ctx.Plan.Entries,
+				libcnb.BuildpackPlanEntry{Name: "jdk", Metadata: LaunchContribution},
+				libcnb.BuildpackPlanEntry{Name: "jre", Metadata: LaunchContribution})
 			ctx.Buildpack.Metadata = map[string]interface{}{
 				"dependencies": []map[string]interface{}{
 					{


### PR DESCRIPTION
## Summary
The test cases were out of sync with the buildplans being retuned from detect, so we missed a case where jre, jdk and native-image-builder were present in the build plan. This triggers a condition where the JRE is installed when it should not be. This PR adds a test to cover this properly & fixes the logic so the JRE is not installed for native-image apps.
## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
