### PR TITLE
Added support for specifying the JRE/JDK versions via the Build Plan TOML metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,52 @@ The Paketo BellSoft Liberica Buildpack is a Cloud Native Buildpack that provides
 
 This buildpack is designed to work in collaboration with other buildpacks which request contributions of JREs and JDKs.
 
+## Integration
+
+Downstream buildpacks can require the JRE/JDK dependency by generating a [Build Plan
+TOML](https://github.com/buildpacks/spec/blob/master/buildpack.md#build-plan-toml)
+file that looks like the following:
+
+```toml
+[[requires]]
+
+  # The name of the JRE dependency is "jre". This value is considered
+  # part of the public API for the buildpack and will not change without a plan
+  # for deprecation.
+  name = "jre"
+
+  # The version of the JRE dependency is not required. In the case it
+  # is not specified, the buildpack will provide the default version, which can
+  # be seen in the buildpack.toml file.
+  # If you wish to request a specific version, the buildpack supports
+  # specifying a semver constraint in the form of "11.*", "11.0.*", or even
+  # "11.0.13".
+  version = "11.0.13"
+
+  # The BellSoft Liberica buildpack supports some non-required metadata options.
+  [requires.metadata]
+    # Setting the launch flag to true will ensure that the BellSoft Liberica
+    # dependency is available on the $PATH for the running application. If you are
+    # writing an application that needs to run node at runtime, this flag should
+    # be set to true.
+    launch = true
+
+[[requires]]
+
+  # The name of the JDK dependency is "jdk". This value is considered
+  # part of the public API for the buildpack and will not change without a plan
+  # for deprecation.
+  name = "jdk"
+
+  # The version of the JDK dependency is not required. In the case it
+  # is not specified, the buildpack will provide the default version, which can
+  # be seen in the buildpack.toml file.
+  # If you wish to request a specific version, the buildpack supports
+  # specifying a semver constraint in the form of "11.*", "11.0.*", or even
+  # "11.0.13".
+  version = "11.0.13"
+```
+
 ## Behavior
 
 This buildpack will participate if any of the following conditions are met

--- a/liberica/build.go
+++ b/liberica/build.go
@@ -139,7 +139,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 			jrePlanEntry.Metadata["cache"] = true
 
 			dt = libjvm.JDKType
-			depJRE, err = dr.Resolve("jdk", jdkVersion)
+			depJRE, err = dr.Resolve("jdk", jreVersion)
 		}
 
 		if err != nil {

--- a/liberica/build_test.go
+++ b/liberica/build_test.go
@@ -372,6 +372,126 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(result.BOM.Entries[1].Launch).To(BeTrue())
 	})
 
+	context("buildplan version specified", func() {
+		it.Before(func() {
+			ctx.Buildpack.Metadata = map[string]interface{}{
+				"configurations": []map[string]interface{}{
+					{
+						"name":    "BP_JVM_VERSION",
+						"default": "1.1.1",
+					},
+				},
+				"dependencies": []map[string]interface{}{
+					{
+						"id":      "jdk",
+						"version": "1.1.1",
+						"stacks":  []interface{}{"test-stack-id"},
+					},
+					{
+						"id":      "jre",
+						"version": "1.1.1",
+						"stacks":  []interface{}{"test-stack-id"},
+					},
+					{
+						"id":      "jdk",
+						"version": "2.2.2",
+						"stacks":  []interface{}{"test-stack-id"},
+					},
+					{
+						"id":      "jre",
+						"version": "2.2.2",
+						"stacks":  []interface{}{"test-stack-id"},
+					},
+					{
+						"id":      "jdk",
+						"version": "3.3.3",
+						"stacks":  []interface{}{"test-stack-id"},
+					},
+					{
+						"id":      "jre",
+						"version": "3.3.3",
+						"stacks":  []interface{}{"test-stack-id"},
+					},
+					{
+						"id":      "jdk",
+						"version": "4.4.4",
+						"stacks":  []interface{}{"test-stack-id"},
+					},
+					{
+						"id":      "jre",
+						"version": "4.4.4",
+						"stacks":  []interface{}{"test-stack-id"},
+					},
+				},
+			}
+			ctx.StackID = "test-stack-id"
+		})
+		it("contributes the default version", func() {
+			ctx.Plan.Entries = append(ctx.Plan.Entries,
+				libcnb.BuildpackPlanEntry{Name: "jdk"},
+				libcnb.BuildpackPlanEntry{Name: "jre"},
+			)
+
+			result, err := liberica.Build{}.Build(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result.Layers[0].(libjvm.JDK).LayerContributor.Dependency.Version).To(Equal("1.1.1"))
+			Expect(result.Layers[1].(libjvm.JRE).LayerContributor.Dependency.Version).To(Equal("1.1.1"))
+		})
+
+		it("contributes the version required by the jre plan entry", func() {
+			ctx.Plan.Entries = append(ctx.Plan.Entries,
+				libcnb.BuildpackPlanEntry{Name: "jdk"},
+				libcnb.BuildpackPlanEntry{Name: "jre", Metadata: map[string]interface{}{"version": "2.2.2"}},
+			)
+
+			result, err := liberica.Build{}.Build(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result.Layers[0].(libjvm.JDK).LayerContributor.Dependency.Version).To(Equal("2.2.2"))
+			Expect(result.Layers[1].(libjvm.JRE).LayerContributor.Dependency.Version).To(Equal("2.2.2"))
+		})
+
+		it("contributes the version required by the jdk plan entry", func() {
+			ctx.Plan.Entries = append(ctx.Plan.Entries,
+				libcnb.BuildpackPlanEntry{Name: "jdk", Metadata: map[string]interface{}{"version": "2.2.2"}},
+				libcnb.BuildpackPlanEntry{Name: "jre"},
+			)
+
+			result, err := liberica.Build{}.Build(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result.Layers[0].(libjvm.JDK).LayerContributor.Dependency.Version).To(Equal("2.2.2"))
+			Expect(result.Layers[1].(libjvm.JRE).LayerContributor.Dependency.Version).To(Equal("2.2.2"))
+		})
+
+		it("contributes the version required by the jdk & jre plan entries", func() {
+			ctx.Plan.Entries = append(ctx.Plan.Entries,
+				libcnb.BuildpackPlanEntry{Name: "jdk", Metadata: map[string]interface{}{"version": "2.2.2"}},
+				libcnb.BuildpackPlanEntry{Name: "jre", Metadata: map[string]interface{}{"version": "3.3.3"}},
+			)
+
+			result, err := liberica.Build{}.Build(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result.Layers[0].(libjvm.JDK).LayerContributor.Dependency.Version).To(Equal("2.2.2"))
+			Expect(result.Layers[1].(libjvm.JRE).LayerContributor.Dependency.Version).To(Equal("3.3.3"))
+		})
+
+		it("contributes the version required by the jdk & jre plan entries", func() {
+			ctx.Plan.Entries = append(ctx.Plan.Entries,
+				libcnb.BuildpackPlanEntry{Name: "jdk", Metadata: map[string]interface{}{"version": "2.2.2"}},
+				libcnb.BuildpackPlanEntry{Name: "jre", Metadata: map[string]interface{}{"version": "3.3.3"}},
+			)
+
+			result, err := liberica.Build{}.Build(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result.Layers[0].(libjvm.JDK).LayerContributor.Dependency.Version).To(Equal("2.2.2"))
+			Expect(result.Layers[1].(libjvm.JRE).LayerContributor.Dependency.Version).To(Equal("3.3.3"))
+		})
+	})
+
 	context("$BP_JVM_VERSION", func() {
 		it.Before(func() {
 			Expect(os.Setenv("BP_JVM_VERSION", "1.1.1")).To(Succeed())
@@ -385,6 +505,44 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			ctx.Plan.Entries = append(ctx.Plan.Entries,
 				libcnb.BuildpackPlanEntry{Name: "jdk"},
 				libcnb.BuildpackPlanEntry{Name: "jre"},
+			)
+			ctx.Buildpack.Metadata = map[string]interface{}{
+				"dependencies": []map[string]interface{}{
+					{
+						"id":      "jdk",
+						"version": "1.1.1",
+						"stacks":  []interface{}{"test-stack-id"},
+					},
+					{
+						"id":      "jdk",
+						"version": "2.2.2",
+						"stacks":  []interface{}{"test-stack-id"},
+					},
+					{
+						"id":      "jre",
+						"version": "1.1.1",
+						"stacks":  []interface{}{"test-stack-id"},
+					},
+					{
+						"id":      "jre",
+						"version": "2.2.2",
+						"stacks":  []interface{}{"test-stack-id"},
+					},
+				},
+			}
+			ctx.StackID = "test-stack-id"
+
+			result, err := liberica.Build{}.Build(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result.Layers[0].(libjvm.JDK).LayerContributor.Dependency.Version).To(Equal("1.1.1"))
+			Expect(result.Layers[1].(libjvm.JRE).LayerContributor.Dependency.Version).To(Equal("1.1.1"))
+		})
+
+		it("contributes the explicitly required JVM version", func() {
+			ctx.Plan.Entries = append(ctx.Plan.Entries,
+				libcnb.BuildpackPlanEntry{Name: "jdk", Metadata: map[string]interface{}{"version": "2.2.2"}},
+				libcnb.BuildpackPlanEntry{Name: "jre", Metadata: map[string]interface{}{"version": "3.3.3"}},
 			)
 			ctx.Buildpack.Metadata = map[string]interface{}{
 				"dependencies": []map[string]interface{}{

--- a/liberica/build_test.go
+++ b/liberica/build_test.go
@@ -490,6 +490,17 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(result.Layers[0].(libjvm.JDK).LayerContributor.Dependency.Version).To(Equal("2.2.2"))
 			Expect(result.Layers[1].(libjvm.JRE).LayerContributor.Dependency.Version).To(Equal("3.3.3"))
 		})
+
+		it("fails if unresolvable jdk version is requested", func() {
+			ctx.Plan.Entries = append(ctx.Plan.Entries,
+				libcnb.BuildpackPlanEntry{Name: "jdk", Metadata: map[string]interface{}{"version": "5.5.5"}},
+				libcnb.BuildpackPlanEntry{Name: "jre", Metadata: map[string]interface{}{"version": "2.2.2"}},
+			)
+
+			_, err := liberica.Build{}.Build(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unable to find dependency\nno valid dependencies for jdk, 5.5.5"))
+		})
 	})
 
 	context("$BP_JVM_VERSION", func() {

--- a/liberica/build_test.go
+++ b/liberica/build_test.go
@@ -442,7 +442,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		it("contributes the version required by the jre plan entry", func() {
 			ctx.Plan.Entries = append(ctx.Plan.Entries,
 				libcnb.BuildpackPlanEntry{Name: "jdk"},
-				libcnb.BuildpackPlanEntry{Name: "jre", Metadata: map[string]interface{}{"version": "2.2.2"}},
+				libcnb.BuildpackPlanEntry{Name: "jre", Metadata: map[string]interface{}{"version": "2.*"}},
 			)
 
 			result, err := liberica.Build{}.Build(ctx)
@@ -454,7 +454,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		it("contributes the version required by the jdk plan entry", func() {
 			ctx.Plan.Entries = append(ctx.Plan.Entries,
-				libcnb.BuildpackPlanEntry{Name: "jdk", Metadata: map[string]interface{}{"version": "2.2.2"}},
+				libcnb.BuildpackPlanEntry{Name: "jdk", Metadata: map[string]interface{}{"version": "2.*"}},
 				libcnb.BuildpackPlanEntry{Name: "jre"},
 			)
 
@@ -467,21 +467,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		it("contributes the version required by the jdk & jre plan entries", func() {
 			ctx.Plan.Entries = append(ctx.Plan.Entries,
-				libcnb.BuildpackPlanEntry{Name: "jdk", Metadata: map[string]interface{}{"version": "2.2.2"}},
-				libcnb.BuildpackPlanEntry{Name: "jre", Metadata: map[string]interface{}{"version": "3.3.3"}},
-			)
-
-			result, err := liberica.Build{}.Build(ctx)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(result.Layers[0].(libjvm.JDK).LayerContributor.Dependency.Version).To(Equal("2.2.2"))
-			Expect(result.Layers[1].(libjvm.JRE).LayerContributor.Dependency.Version).To(Equal("3.3.3"))
-		})
-
-		it("contributes the version required by the jdk & jre plan entries", func() {
-			ctx.Plan.Entries = append(ctx.Plan.Entries,
-				libcnb.BuildpackPlanEntry{Name: "jdk", Metadata: map[string]interface{}{"version": "2.2.2"}},
-				libcnb.BuildpackPlanEntry{Name: "jre", Metadata: map[string]interface{}{"version": "3.3.3"}},
+				libcnb.BuildpackPlanEntry{Name: "jdk", Metadata: map[string]interface{}{"version": "2.*"}},
+				libcnb.BuildpackPlanEntry{Name: "jre", Metadata: map[string]interface{}{"version": "3.*"}},
 			)
 
 			result, err := liberica.Build{}.Build(ctx)
@@ -493,13 +480,24 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		it("fails if unresolvable jdk version is requested", func() {
 			ctx.Plan.Entries = append(ctx.Plan.Entries,
-				libcnb.BuildpackPlanEntry{Name: "jdk", Metadata: map[string]interface{}{"version": "5.5.5"}},
-				libcnb.BuildpackPlanEntry{Name: "jre", Metadata: map[string]interface{}{"version": "2.2.2"}},
+				libcnb.BuildpackPlanEntry{Name: "jdk", Metadata: map[string]interface{}{"version": "5.*"}},
+				libcnb.BuildpackPlanEntry{Name: "jre", Metadata: map[string]interface{}{"version": "2.*"}},
 			)
 
 			_, err := liberica.Build{}.Build(ctx)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("unable to find dependency\nno valid dependencies for jdk, 5.5.5"))
+			Expect(err.Error()).To(ContainSubstring("unable to find dependency\nno valid dependencies for jdk, 5.*"))
+		})
+
+		it("fails if unresolvable jre version is requested", func() {
+			ctx.Plan.Entries = append(ctx.Plan.Entries,
+				libcnb.BuildpackPlanEntry{Name: "jdk", Metadata: map[string]interface{}{"version": "2.*"}},
+				libcnb.BuildpackPlanEntry{Name: "jre", Metadata: map[string]interface{}{"version": "5.*"}},
+			)
+
+			_, err := liberica.Build{}.Build(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unable to find dependency\nno valid dependencies for jdk, 5.*"))
 		})
 	})
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Added support for specifying the JRE/JDK versions via the Build Plan TOML metadata

## Use Cases
[executable-jar](https://github.com/paketo-buildpacks/executable-jar) buildpack (https://github.com/paketo-buildpacks/executable-jar/pull/99) could request specific JVM version, based on the metadata of the JAR/WAR files (with which version it was built).

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
