### PR TITLE
Extract JVM version from Maven MANIFEST.MF entries

### DIFF
--- a/liberica/build.go
+++ b/liberica/build.go
@@ -57,7 +57,11 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	cl := libjvm.NewCertificateLoader()
 	cl.Logger = b.Logger.BodyWriter()
 
-	v, _ := cr.Resolve("BP_JVM_VERSION")
+	jvmVersion := libjvm.JVMVersion{Logger: b.Logger}
+	v, err := jvmVersion.GetJVMVersion(context.Application.Path, cr)
+	if err != nil {
+		return libcnb.BuildResult{}, fmt.Errorf("unable to determine jvm version\n%w", err)
+	}
 
 	jreSkipped := false
 	if t, _ := cr.Resolve("BP_JVM_TYPE"); strings.ToLower(t) == "jdk" {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

See https://github.com/paketo-buildpacks/libjvm/pull/131

This Java buildpack seems to implement its own `Build` method instead of delegating to `libjvm` (as for example `sap-machine` and `microsoft-openjdk` buildpacks do). Therefore we applied the same changes as in the linked PR here (calling a method in `libjvm` which implements the version detection). 

## Use Cases
<!-- An explanation of the use cases your change enables -->

See https://github.com/paketo-buildpacks/libjvm/pull/131

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
