### PR TITLE
Disabled certificate loader helper for Java 18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/buildpacks/libcnb v1.25.5
 	github.com/heroku/color v0.0.6
 	github.com/onsi/gomega v1.19.0
-	github.com/paketo-buildpacks/libjvm v1.36.0
+	github.com/paketo-buildpacks/libjvm v1.36.1
 	github.com/paketo-buildpacks/libpak v1.59.0
 	github.com/sclevine/spec v1.4.0
 )
@@ -21,7 +21,7 @@ require (
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mattn/go-shellwords v1.0.12 // indirect
-	github.com/miekg/dns v1.1.47 // indirect
+	github.com/miekg/dns v1.1.48 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/pavel-v-chernykh/keystore-go/v4 v4.3.0 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,8 @@ github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
-github.com/miekg/dns v1.1.47 h1:J9bWiXbqMbnZPcY8Qi2E3EWIBsIm6MZzzJB9VRg5gL8=
-github.com/miekg/dns v1.1.47/go.mod h1:e3IlAVfNqAllflbibAZEWOXOQ+Ynzk/dDozDxY7XnME=
+github.com/miekg/dns v1.1.48 h1:Ucfr7IIVyMBz4lRE8qmGUuZ4Wt3/ZGu9hmcMT3Uu4tQ=
+github.com/miekg/dns v1.1.48/go.mod h1:e3IlAVfNqAllflbibAZEWOXOQ+Ynzk/dDozDxY7XnME=
 github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
 github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
@@ -67,8 +67,8 @@ github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAl
 github.com/onsi/gomega v1.18.1/go.mod h1:0q+aL8jAiMXy9hbwj2mr5GziHiwhAIQpFmmtT5hitRs=
 github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
-github.com/paketo-buildpacks/libjvm v1.36.0 h1:6vl5U4zi4r3VwEhmMM120opVvDef2RPHywqXmKya7KE=
-github.com/paketo-buildpacks/libjvm v1.36.0/go.mod h1:Dmq4GWZX8OIwVWYA0aDFeimCj3jkq1vKI8+p9YNO8vo=
+github.com/paketo-buildpacks/libjvm v1.36.1 h1:kIPOofngQ3vgfhGvVoZoNnCK6JjUx+wfQVmpfsNulq4=
+github.com/paketo-buildpacks/libjvm v1.36.1/go.mod h1:EeBvWpuHvCVciE9oYBSdqFzBvCQKwzVyhxzvT7QwbJY=
 github.com/paketo-buildpacks/libpak v1.59.0 h1:9Kt1G0IZZbnIrgsfxU9SuAqJB5EBnVwNJqMgw5qFMa0=
 github.com/paketo-buildpacks/libpak v1.59.0/go.mod h1:hqdnjXrMRmt25/tw+FLC3UbT2uQXH1et2zZ8Br3ZXAo=
 github.com/pavel-v-chernykh/keystore-go/v4 v4.3.0 h1:TVckDDIKzWo9/cPdsvyikdmnnKIPeWgnGoekhQM5zBc=

--- a/liberica/build.go
+++ b/liberica/build.go
@@ -157,7 +157,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 
 		if libjvm.IsLaunchContribution(jrePlanEntry.Metadata) {
 			helpers := []string{"active-processor-count", "java-opts", "jvm-heap", "link-local-dns", "memory-calculator",
-				"openssl-certificate-loader", "security-providers-configurer", "jmx", "jfr", "nmt"}
+				"security-providers-configurer", "jmx", "jfr", "nmt"}
 
 			if libjvm.IsBeforeJava9(depJRE.Version) {
 				helpers = append(helpers, "security-providers-classpath-8")
@@ -165,6 +165,10 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 			} else {
 				helpers = append(helpers, "security-providers-classpath-9")
 				helpers = append(helpers, "debug-9")
+			}
+			// Java 18 bug - cacerts keystore type not readable
+			if libjvm.IsBeforeJava18(depJRE.Version) {
+				helpers = append(helpers, "openssl-certificate-loader")
 			}
 
 			h, be := libpak.NewHelperLayer(context.Buildpack, helpers...)

--- a/liberica/build_test.go
+++ b/liberica/build_test.go
@@ -276,13 +276,13 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			"jvm-heap",
 			"link-local-dns",
 			"memory-calculator",
-			"openssl-certificate-loader",
 			"security-providers-configurer",
 			"jmx",
 			"jfr",
 			"nmt",
 			"security-providers-classpath-8",
 			"debug-8",
+			"openssl-certificate-loader",
 		}))
 	})
 
@@ -310,13 +310,13 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			"jvm-heap",
 			"link-local-dns",
 			"memory-calculator",
-			"openssl-certificate-loader",
 			"security-providers-configurer",
 			"jmx",
 			"jfr",
 			"nmt",
 			"security-providers-classpath-9",
 			"debug-9",
+			"openssl-certificate-loader",
 		}))
 	})
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Workaround for https://github.com/paketo-buildpacks/libjvm/issues/158 - this PR disables loading the default cacerts keystore & entries when using Java 18. The ca-certificates buildpack cannot be used with Java 18 until there is a permanent resolution.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
