### PR TITLE
Add Bellsoft Liberica native-image 21

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -72,6 +72,15 @@ dependencies:
     product: nik
     type:    core
     version: "17"
+- name:            Native Image 21
+  id:              native-image-svm
+  version_pattern: "21\\.[\\d]+\\.[\\d]+"
+  uses:            docker://ghcr.io/paketo-buildpacks/actions/bellsoft-liberica-dependency:main
+  purl_pattern:    "[\\d]+\\.[\\d]+\\.[\\d]+\\.?[\\d]?"
+  with:
+    product: nik
+    type:    core
+    version: "21"
 - name:            JDK 17
   id:              jdk
   version_pattern: "17\\.[\\d]+\\.[\\d]+"

--- a/.github/workflows/pb-update-native-image-21.yml
+++ b/.github/workflows/pb-update-native-image-21.yml
@@ -1,0 +1,112 @@
+name: Update Native Image 21
+"on":
+    schedule:
+        - cron: 0 5 * * 1-5
+    workflow_dispatch: {}
+jobs:
+    update:
+        name: Update Buildpack Dependency
+        runs-on:
+            - ubuntu-latest
+        steps:
+            - uses: actions/setup-go@v4
+              with:
+                go-version: "1.20"
+            - name: Install update-buildpack-dependency
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-buildpack-dependency@latest
+            - name: Install yj
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "Installing yj ${YJ_VERSION}"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl \
+                  --location \
+                  --show-error \
+                  --silent \
+                  --output "${HOME}"/bin/yj \
+                  "https://github.com/sclevine/yj/releases/download/v${YJ_VERSION}/yj-linux"
+
+                chmod +x "${HOME}"/bin/yj
+              env:
+                YJ_VERSION: 5.0.0
+            - uses: actions/checkout@v3
+            - id: dependency
+              uses: docker://ghcr.io/paketo-buildpacks/actions/bellsoft-liberica-dependency:main
+              with:
+                product: nik
+                type: core
+                version: "21"
+            - name: Update Buildpack Dependency
+              id: buildpack
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                OLD_VERSION=$(yj -tj < buildpack.toml | jq -r "
+                  .metadata.dependencies[] |
+                  select( .id == env.ID ) |
+                  select( .version | test( env.VERSION_PATTERN ) ) |
+                  .version")
+
+                update-buildpack-dependency \
+                  --buildpack-toml buildpack.toml \
+                  --id "${ID}" \
+                  --version-pattern "${VERSION_PATTERN}" \
+                  --version "${VERSION}" \
+                  --cpe-pattern "${CPE_PATTERN:-}" \
+                  --cpe "${CPE:-}" \
+                  --purl-pattern "${PURL_PATTERN:-}" \
+                  --purl "${PURL:-}" \
+                  --uri "${URI}" \
+                  --sha256 "${SHA256}"
+
+                git add buildpack.toml
+                git checkout -- .
+
+                if [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $1}')" != "$(echo "$VERSION" | awk -F '.' '{print $1}')" ]; then
+                  LABEL="semver:major"
+                elif [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $2}')" != "$(echo "$VERSION" | awk -F '.' '{print $2}')" ]; then
+                  LABEL="semver:minor"
+                else
+                  LABEL="semver:patch"
+                fi
+
+                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
+                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
+                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
+              env:
+                CPE: ${{ steps.dependency.outputs.cpe }}
+                CPE_PATTERN: ""
+                ID: native-image-svm
+                PURL: ${{ steps.dependency.outputs.purl }}
+                PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.?[\d]?'
+                SHA256: ${{ steps.dependency.outputs.sha256 }}
+                URI: ${{ steps.dependency.outputs.uri }}
+                VERSION: ${{ steps.dependency.outputs.version }}
+                VERSION_PATTERN: 21\.[\d]+\.[\d]+
+            - uses: peter-evans/create-pull-request@v5
+              with:
+                author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
+                body: Bumps `Native Image 21` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
+                branch: update/buildpack/native-image-21
+                commit-message: |-
+                    Bump Native Image 21 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+
+                    Bumps Native Image 21 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
+                delete-branch: true
+                labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
+                signoff: true
+                title: Bump Native Image 21 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -278,6 +278,20 @@ api = "0.7"
       type = "GPL-2.0 WITH Classpath-exception-2.0"
       uri = "https://openjdk.java.net/legal/gplv2+ce.html"
 
+  [[metadata.dependencies]]
+    cpes = ["cpe:2.3:a:oracle:graalvm:22.3.0:*:*:*:community:*:*:*", "cpe:2.3:a:oracle:jdk:21.0.0:*:*:*:*:*:*:*"]
+    id = "native-image-svm"
+    name = "BellSoft Liberica NIK"
+    purl = "pkg:generic/bellsoft-nik@23.1.0?arch=amd64"
+    sha256 = "46ead210117847336d02d234cf2449f38b5973d1161eddd807b101c9a96b9020"
+    stacks = ["io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny", "*"]
+    uri = "https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-core-openjdk21+37-23.1.0+1-linux-amd64.tar.gz"
+    version = "21.0.0"
+
+    [[metadata.dependencies.licenses]]
+      type = "GPL-2.0 WITH Classpath-exception-2.0"
+      uri = "https://openjdk.java.net/legal/gplv2+ce.html"
+
 [[stacks]]
   id = "io.paketo.stacks.tiny"
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR adds the native-image support for Java 21

## Use Cases
<!-- An explanation of the use cases your change enables -->
Building native-image with Java 21
## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
