### PR TITLE
Change arm to arm64 for the upate jobs

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -124,7 +124,7 @@ dependencies:
     product: liberica
     type:    jdk
     version: "8"
-    arch:    arm
+    arch:    arm64
 - name:            JRE 8 ARM64
   id:              jre
   version_pattern: "^8\\.[\\d]+\\.[\\d]+"
@@ -134,7 +134,7 @@ dependencies:
     product: liberica
     type:    jre
     version: "8"
-    arch:    arm
+    arch:    arm64
 - name:            JDK 11 ARM64
   id:              jdk
   version_pattern: "11\\.[\\d]+\\.[\\d]+"
@@ -143,7 +143,7 @@ dependencies:
     product: liberica
     type:    jdk
     version: "11"
-    arch:    arm
+    arch:    arm64
 - name:            JRE 11 ARM64
   id:              jre
   version_pattern: "11\\.[\\d]+\\.[\\d]+"
@@ -152,7 +152,7 @@ dependencies:
     product: liberica
     type:    jre
     version: "11"
-    arch:    arm
+    arch:    arm64
 - name:            Native Image 11 ARM64
   id:              native-image-svm
   version_pattern: "11\\.[\\d]+\\.[\\d]+"
@@ -162,7 +162,7 @@ dependencies:
     product: nik
     type:    core
     version: "11"
-    arch:    arm
+    arch:    arm64
 - name:            Native Image 17 ARM64
   id:              native-image-svm
   version_pattern: "17\\.[\\d]+\\.[\\d]+"
@@ -172,7 +172,7 @@ dependencies:
     product: nik
     type:    core
     version: "17"
-    arch:    arm
+    arch:    arm64
 - name:            Native Image 21 ARM64
   id:              native-image-svm
   version_pattern: "21\\.[\\d]+\\.[\\d]+"
@@ -182,7 +182,7 @@ dependencies:
     product: nik
     type:    core
     version: "21"
-    arch:    arm
+    arch:    arm64
 - name:            JDK 17 ARM64
   id:              jdk
   version_pattern: "17\\.[\\d]+\\.[\\d]+"
@@ -191,7 +191,7 @@ dependencies:
     product: liberica
     type:    jdk
     version: "17"
-    arch:    arm
+    arch:    arm64
 - name:            JRE 17 ARM64
   id:              jre
   version_pattern: "17\\.[\\d]+\\.[\\d]+"
@@ -200,7 +200,7 @@ dependencies:
     product: liberica
     type:    jre
     version: "17"
-    arch:    arm
+    arch:    arm64
 - name:            JDK 21 ARM64
   id:              jdk
   version_pattern: "21\\.[\\d]+\\.[\\d]+"
@@ -209,7 +209,7 @@ dependencies:
     product: liberica
     type:    jdk
     version: "21"
-    arch:    arm
+    arch:    arm64
 - name:            JRE 21 ARM64
   id:              jre
   version_pattern: "21\\.[\\d]+\\.[\\d]+"
@@ -218,4 +218,4 @@ dependencies:
     product: liberica
     type:    jre
     version: "21"
-    arch:    arm
+    arch:    arm64


### PR DESCRIPTION
## Summary

Update to use arm64 cause that's what we use elsewhere. The action has been changed to accept this and convert to arm where needed.

https://github.com/paketo-buildpacks/pipeline-builder/pull/1438

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
