### PR TITLE
Revert "Bump Native Image 21 from 21.0.3 to 21.0.4"

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -523,16 +523,16 @@ api = "0.7"
       uri = "https://openjdk.java.net/legal/gplv2+ce.html"
 
   [[metadata.dependencies]]
-    cpes = ["cpe:2.3:a:oracle:graalvm:23.1.1:*:*:*:community:*:*:*", "cpe:2.3:a:oracle:jdk:21.0.4:*:*:*:*:*:*:*"]
+    cpes = ["cpe:2.3:a:oracle:graalvm:23.1.1:*:*:*:community:*:*:*", "cpe:2.3:a:oracle:jdk:21.0.3:*:*:*:*:*:*:*"]
     id = "native-image-svm"
     name = "BellSoft Liberica NIK"
-    purl = "pkg:generic/bellsoft-nik@23.1.4?arch=arm64"
-    sha256 = "7c4de630f14556ba30725e0bb950ba25551a49a48b3d6ec90f40f2dfc49f9803"
-    source = "https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+1-21.0.4+9/bellsoft-liberica-vm-openjdk21.0.4+9-23.1.4+1-src.tar.gz"
-    source-sha256 = "65f3df51d17c993a95107f0275c3f958f796157a656a4221d70763e5338d16d8"
+    purl = "pkg:generic/bellsoft-nik@23.1.3?arch=arm64"
+    sha256 = "c1906cbce777683fceee313cbd9851253be65f78bb48791d118cdadaa1995e2e"
+    source = "https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-openjdk21.0.3+10-23.1.3+2-src.tar.gz"
+    source-sha256 = "fc94f9c32b6c2400c0bf1cebe5d8fb438c85622aeca2aeab6a97c1fb124f7c47"
     stacks = ["*"]
-    uri = "https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+1-21.0.4+9/bellsoft-liberica-vm-core-openjdk21.0.4+9-23.1.4+1-linux-aarch64.tar.gz"
-    version = "21.0.4"
+    uri = "https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-core-openjdk21.0.3+10-23.1.3+2-linux-aarch64.tar.gz"
+    version = "21.0.3"
 
     [[metadata.dependencies.licenses]]
       type = "GPL-2.0 WITH Classpath-exception-2.0"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -347,16 +347,16 @@ api = "0.7"
       uri = "https://openjdk.java.net/legal/gplv2+ce.html"
 
   [[metadata.dependencies]]
-    cpes = ["cpe:2.3:a:oracle:graalvm:23.1.1:*:*:*:community:*:*:*", "cpe:2.3:a:oracle:jdk:21.0.4:*:*:*:*:*:*:*"]
+    cpes = ["cpe:2.3:a:oracle:graalvm:23.1.1:*:*:*:community:*:*:*", "cpe:2.3:a:oracle:jdk:21.0.3:*:*:*:*:*:*:*"]
     id = "native-image-svm"
     name = "BellSoft Liberica NIK"
-    purl = "pkg:generic/bellsoft-nik@23.1.4?arch=amd64"
-    sha256 = "38751a6adc73c03b8fdb8cb01318d09858c68b3dacedd5d404427c5396ec001c"
-    source = "https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+1-21.0.4+9/bellsoft-liberica-vm-openjdk21.0.4+9-23.1.4+1-src.tar.gz"
-    source-sha256 = "65f3df51d17c993a95107f0275c3f958f796157a656a4221d70763e5338d16d8"
+    purl = "pkg:generic/bellsoft-nik@23.1.3?arch=amd64"
+    sha256 = "03e6997a84f6fa13d206782a24ef5d657893949784c16b24ff24937b96e2f045"
+    source = "https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-openjdk21.0.3+10-23.1.3+2-src.tar.gz"
+    source-sha256 = "fc94f9c32b6c2400c0bf1cebe5d8fb438c85622aeca2aeab6a97c1fb124f7c47"
     stacks = ["*"]
-    uri = "https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+1-21.0.4+9/bellsoft-liberica-vm-core-openjdk21.0.4+9-23.1.4+1-linux-amd64.tar.gz"
-    version = "21.0.4"
+    uri = "https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-core-openjdk21.0.3+10-23.1.3+2-linux-amd64.tar.gz"
+    version = "21.0.3"
 
     [[metadata.dependencies.licenses]]
       type = "GPL-2.0 WITH Classpath-exception-2.0"


### PR DESCRIPTION
This reverts commit 09d3be155b23e901e2ef9dcffa3c91c4190e217d.

because 21.0.4 seems to have an issue with virtual threads

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
